### PR TITLE
Ability to include theme without importing bootstrap from pre-defined path added

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ $ composer require apalfrey/select2-bootstrap-5-theme
 #### SCSS
 ```scss
 @import "node_modules/select2/src/scss/core";
-@import "node_modules/select2-bootstrap-5-theme/src/select2-bootstrap-5-theme";
+@import "node_modules/select2-bootstrap-5-theme/src/include-all";
 ```
 
 ## Usage

--- a/src/_include-all.scss
+++ b/src/_include-all.scss
@@ -1,0 +1,10 @@
+@import "variables";
+
+@import "layout";
+@import "dropdown";
+@import "single";
+@import "multiple";
+@import "disabled";
+@import "input-group";
+@import "validation";
+@import "sizing";

--- a/src/select2-bootstrap-5-theme.scss
+++ b/src/select2-bootstrap-5-theme.scss
@@ -6,13 +6,4 @@
 @import "node_modules/bootstrap/scss/variables";
 @import "node_modules/bootstrap/scss/mixins";
 
-@import "variables";
-
-@import "layout";
-@import "dropdown";
-@import "single";
-@import "multiple";
-@import "disabled";
-@import "input-group";
-@import "validation";
-@import "sizing";
+@import "include-all";


### PR DESCRIPTION
I have bootstrap 5 as part of my project already. So I do not need this theme to be compiled as separate css but include it in my composite css.

When I include `select2-bootstrap-5-theme.scss` I have problem with this lines:
`@import "node_modules/bootstrap/scss/xxx";`

This is because I have bootstrap at another path (I do not use npm in this project at all).

With this pull request I add `_include-all.scss` file to be included separately in such custom cases. And `select2-bootstrap-5-theme.scss` just imports it after importing bootstrap dependencies.

Checked everything to be compiled with gulp.