### PR TITLE
Default font for controls inherited from bootstrap settings

### DIFF
--- a/src/_variables.scss
+++ b/src/_variables.scss
@@ -7,7 +7,7 @@ $s2bs5-padding-y:                $form-select-padding-y !default;
 $s2bs5-padding-x:                $form-select-padding-x !default;
 
 // Font
-$s2bs5-font-family:              $font-family-sans-serif !default;
+$s2bs5-font-family:              inherit !default;
 $s2bs5-font-size:                $form-select-font-size !default;
 $s2bs5-font-weight:              $form-select-font-weight !default;
 $s2bs5-line-height:              $form-select-line-height !default;


### PR DESCRIPTION
Changed font settings to 
`$s2bs5-font-family:              inherit !default;`

We use custom font for bootstrap controls. So when use your original default value (`$font-family-sans-serif`) all select2 controls look different.

I think it would be much more cleaner to inherit default font from bootstrap settings. If someone want to override it it can be done by changing this variable before including this theme.