### PR TITLE
Update _dropdown.scss

### DIFF
--- a/src/_dropdown.scss
+++ b/src/_dropdown.scss
@@ -1,6 +1,7 @@
 .select2-container--bootstrap-5 {
     // Dropdown
     .select2-dropdown {
+        z-index: 1056;
         border-color: $s2bs5-border-color;
         @include border-radius($s2bs5-border-radius);
 


### PR DESCRIPTION
Fixes #49 .

As the new z-index default in Bootstrap5 for a modal is 1055 (instead of 1050), the z-index for the dropdown should be 1056 (instead of 1051). Currently this default 1051 value is handled in the select2 main repository (https://github.com/select2/select2/blob/develop/src/scss/_dropdown.scss), which shouldn't change to stay compatible with Bootstrap4. Hence that PR in this project.