### PR TITLE
Remove form element requirement from validation

### DIFF
--- a/src/_validation.scss
+++ b/src/_validation.scss
@@ -1,7 +1,7 @@
 .select2-container--bootstrap-5 {
     // Valid
     .is-valid + &,
-    form.was-validated select:valid + & {
+    .was-validated select:valid + & {
         // Set border color
         .select2-selection {
             border-color: $s2bs5-valid-border-color;
@@ -32,7 +32,7 @@
 
     // Invalid
     .is-invalid + &,
-    form.was-validated select:invalid + & {
+    .was-validated select:invalid + & {
         // Set border color
         .select2-selection {
             border-color: $s2bs5-invalid-border-color;


### PR DESCRIPTION
The `form` element is not included in the CSS selector from bootstrap. Therefore, it shouldn't be in this theme either.
![](https://i.imgur.com/Uvzmm1B.png)